### PR TITLE
Update contributors quick start guide

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -77,7 +77,7 @@ Docker Community Edition
     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
     $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-2. Install Docker Engine, containerd, and Docker Compose Plugin
+1. Install Docker Engine, containerd
 
 .. code-block:: bash
 
@@ -91,9 +91,10 @@ Docker Community Edition
   sudo groupadd docker
   sudo usermod -aG docker $USER
 
-Note : This is done so a non-root user can access the ``docker`` command.
-After adding user to docker group Logout and Login again for group membership re-evaluation.
-On some Linux distributions, the system automatically creates this group.
+.. note::
+    This is done so a non-root user can access the ``docker`` command.
+    After adding user to docker group Logout and Login again for group membership re-evaluation.
+    On some Linux distributions, the system automatically creates this group.
 
 4. Test Docker installation
 
@@ -101,7 +102,8 @@ On some Linux distributions, the system automatically creates this group.
 
   docker run hello-world
 
-Note : Read more about `Linux post-installation steps for Docker Engine <https://docs.docker.com/engine/install/linux-postinstall/>`_.
+.. note::
+    Read more about `Linux post-installation steps for Docker Engine <https://docs.docker.com/engine/install/linux-postinstall/>`_.
 
 Colima
 ------
@@ -147,10 +149,11 @@ Install manually:
 
   sudo chmod +x /usr/local/bin/docker-compose
 
-Note: This option requires you to manage updates manually.
-It is recommended that you set up Docker's repository for easier maintenance.
+.. note::
+    This option requires you to manage updates manually.
+    It is recommended that you set up Docker's repository for easier maintenance.
 
-2. Verifying installation
+1. Verifying installation
 
 .. code-block:: bash
 
@@ -217,9 +220,10 @@ Forking and cloning Project
    to clone the repo locally (you can also do it in your IDE - see the `Using your IDE`_
    chapter below
 
-Note: For windows based machines, on cloning, the Git line endings may be different from unix based systems
-and might lead to unexpected behaviour on running breeze tooling. Manually setting a property will mitigate this issue.
-Set it to true for windows.
+.. note::
+    For windows based machines, on cloning, the Git line endings may be different from unix based systems
+    and might lead to unexpected behaviour on running breeze tooling. Manually setting a property will mitigate this issue.
+    Set it to true for windows.
 
 .. code-block:: bash
 
@@ -443,9 +447,10 @@ If Airflow was started with ``breeze --python 3.9 --backend postgres``:
   root@f3619b74c59a:/opt/airflow# exit
   breeze down
 
-Note : ``stop_airflow`` is available only when Airflow is started with ``breeze start-airflow``.
+.. note::
+    ``stop_airflow`` is available only when Airflow is started with ``breeze start-airflow``.
 
-5. Knowing more about Breeze
+1. Knowing more about Breeze
 
 .. code-block:: bash
 
@@ -479,14 +484,11 @@ tests are applied when you commit your code.
 To avoid burden on CI infrastructure and to save time, Pre-commit hooks can be run locally before committing changes.
 
 .. note::
-
     We have recently started to recommend ``uv`` for our local development.
 
 .. note::
-
     Remember to have global python set to Python >= 3.9 - Python 3.8 is end-of-life already and we've
     started to use Python 3.9+ features in Airflow and accompanying scripts.
-
 
 Installing pre-commit is best done with ``uv`` (recommended) or ``pipx``.
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -169,7 +169,7 @@ Setting up virtual-env
 
 .. code-block:: bash
 
-  sudo apt install openssl sqlite default-libmysqlclient-dev libmysqlclient-dev postgresql
+  sudo apt install openssl sqlite3 default-libmysqlclient-dev libmysqlclient-dev postgresql
 
 If you want to install all airflow providers, more system dependencies might be needed. For example on Debian/Ubuntu
 like system, this command will install all necessary dependencies that should be installed when you use
@@ -312,7 +312,6 @@ Setting up Breeze
 
 .. code-block:: bash
 
-  root@b76fcb399bb6:/opt/airflow#
   root@b76fcb399bb6:/opt/airflow# exit
 
 8. You can stop the environment (which means deleting the databases and database servers running in the
@@ -329,7 +328,10 @@ Using Breeze
 1. Starting breeze environment using ``breeze start-airflow`` starts Breeze environment with last configuration run(
    In this case python and backend will be picked up from last execution ``breeze --python 3.9 --backend postgres``)
    It also automatically starts webserver, backend and scheduler. It drops you in tmux with scheduler in bottom left
-   and webserver in bottom right. Use ``[Ctrl + B] and Arrow keys`` to navigate
+   and webserver in bottom right. Use ``[Ctrl + B] and Arrow keys`` to navigate.
+   Keep in mind, you need ``pre-commit`` installed for this to work or you will be prompted with
+   ``FileNotFoundError: [Errno 2] No such file or directory: 'pre-commit'``
+   when attempting to invoke ``breeze start-airflow``.
 
 .. code-block:: bash
 
@@ -427,12 +429,21 @@ Using Breeze
       </div>
 
 4. Stopping breeze
+If Airflow was started with ``breeze start-airflow``:
 
 .. code-block:: bash
 
   root@f3619b74c59a:/opt/airflow# stop_airflow
+  breeze down
+
+If Airflow was started with ``breeze --python 3.9 --backend postgres``:
+
+.. code-block:: bash
+
   root@f3619b74c59a:/opt/airflow# exit
   breeze down
+
+Note : ``stop_airflow`` is available only when Airflow is started with ``breeze start-airflow``.
 
 5. Knowing more about Breeze
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -124,14 +124,14 @@ If you use Colima as your container runtimes engine, please follow the next step
 Docker Compose
 --------------
 
-1. Installing latest version of Docker Compose
-Install plugin using the repository:
+1. Installing latest version of the Docker Compose plugin
+Install using the repository:
 
 .. code-block:: bash
   sudo apt-get update
   sudo apt-get install docker-compose-plugin
 
-Install plugin manually:
+Install manually:
 
 .. code-block:: bash
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -636,7 +636,7 @@ Installing airflow in the local venv
 
 .. code-block:: bash
 
-  sudo apt-get install sqlite libsqlite3-dev default-libmysqlclient-dev postgresql
+  sudo apt-get install sqlite3 libsqlite3-dev default-libmysqlclient-dev postgresql
   ./scripts/tools/initialize_virtualenv.py
 
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -91,7 +91,7 @@ Docker Community Edition
   sudo groupadd docker
   sudo usermod -aG docker $USER
 
-Note : This is done so a non-root user can access the `docker` command.
+Note : This is done so a non-root user can access the ``docker`` command.
 After adding user to docker group Logout and Login again for group membership re-evaluation.
 On some Linux distributions, the system automatically creates this group.
 
@@ -225,8 +225,8 @@ Set it to true for windows.
 
   git config core.autocrlf true
 
-Typical development tasks
-#########################
+Setting up Breeze
+-----------------
 
 For many of the development tasks you will need ``Breeze`` to be configured. ``Breeze`` is a development
 environment which uses docker and docker-compose and its main purpose is to provide a consistent
@@ -234,9 +234,6 @@ and repeatable environment for all the contributors and CI. When using ``Breeze`
 syndrome - because not only others can reproduce easily what you do, but also the CI of Airflow uses
 the same environment to run all tests - so you should be able to easily reproduce the same failures you
 see in CI in your local environment.
-
-Setting up Breeze
------------------
 
 1. Install ``uv`` or ``pipx``. We recommend to install ``uv`` as general purpose python development
    environment - you can install it via https://docs.astral.sh/uv/getting-started/installation/ or you can
@@ -491,27 +488,13 @@ To avoid burden on CI infrastructure and to save time, Pre-commit hooks can be r
     started to use Python 3.9+ features in Airflow and accompanying scripts.
 
 
-Installing pre-commit is best done with ``uv`` (recommended) or ``pipx``:
-
-This will install ``pre-commit`` with ``uv``, and it will change it to use ``uv`` to install its own
-virtualenvs.
-
-.. code-block:: bash
-
-    uv tool install pre-commit --with pre-commit-uv
-
-or
-
-.. code-block:: bash
-
-    pipx install pre-commit
+Installing pre-commit is best done with ``uv`` (recommended) or ``pipx``.
 
 You can add ``uv`` support for ``pre-commit`` even you install it with ``pipx`` using the commands
 (then pre-commit will use ``uv`` to create virtualenvs for the hooks):
 
 .. code-block:: bash
 
-    pipx install pre-commit
     pipx inject pre-commit pre-commit-uv  # optionally if you want to use uv to install virtualenvs
 
 1.  Installing required packages
@@ -528,7 +511,7 @@ on macOS, install via
 
   brew install libxml2
 
-2. Installing pre-commit (if you have not done it yet):
+2. Installing pre-commit:
 
 .. code-block:: bash
 
@@ -539,7 +522,7 @@ or
 .. code-block:: bash
 
   pipx install pre-commit
-  pipx install inject pre-commit pre-commit-uv
+  pipx install inject pre-commit pre-commit-uv # optional, configures pre-commit to use uv to install virtualenvs
 
 3. Go to your project directory
 
@@ -690,18 +673,12 @@ All Tests are inside ./tests directory.
 
 - Running specific type of test
 
-  - Types of tests
-
-  - Running specific type of test
-
   .. code-block:: bash
 
     breeze --backend postgres --postgres-version 15 --python 3.9 --db-reset testing tests --test-type Core
 
 
 - Running Integration test for specific test type
-
-  - Running an Integration Test
 
   .. code-block:: bash
 
@@ -713,7 +690,9 @@ All Tests are inside ./tests directory.
 
    <a href="https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst" target="_blank">09_testing.rst</a>
 
-  - |Local and Remote Debugging in IDE|
+- Similarly to regular development, you can also debug while testing using your IDE, for more information, you may refer to
+
+  |Local and Remote Debugging in IDE|
 
   .. |Local and Remote Debugging in IDE| raw:: html
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -125,6 +125,7 @@ Docker Compose
 --------------
 
 1. Installing latest version of the Docker Compose plugin
+
 Install using the repository:
 
 .. code-block:: bash
@@ -429,6 +430,7 @@ Using Breeze
       </div>
 
 4. Stopping breeze
+
 If Airflow was started with ``breeze start-airflow``:
 
 .. code-block:: bash

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -129,6 +129,7 @@ Docker Compose
 Install using the repository:
 
 .. code-block:: bash
+
   sudo apt-get update
   sudo apt-get install docker-compose-plugin
 

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -82,22 +82,26 @@ Docker Community Edition
 .. code-block:: bash
 
   sudo apt-get update
-  sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+  sudo apt-get install docker-ce docker-ce-cli containerd.io
 
-3. Creating group for docker and adding current user to it
+3. Manage docker as non-root user
 
 .. code-block:: bash
 
   sudo groupadd docker
   sudo usermod -aG docker $USER
 
-Note : After adding user to docker group Logout and Login again for group membership re-evaluation.
+Note : This is done so a non-root user can access the `docker` command.
+After adding user to docker group Logout and Login again for group membership re-evaluation.
+On some Linux distributions, the system automatically creates this group.
 
 4. Test Docker installation
 
 .. code-block:: bash
 
   docker run hello-world
+
+Note : Read more about `Linux post-installation steps for Docker Engine <https://docs.docker.com/engine/install/linux-postinstall/>`_.
 
 Colima
 ------
@@ -121,6 +125,13 @@ Docker Compose
 --------------
 
 1. Installing latest version of Docker Compose
+Install plugin using the repository:
+
+.. code-block:: bash
+  sudo apt-get update
+  sudo apt-get install docker-compose-plugin
+
+Install plugin manually:
 
 .. code-block:: bash
 
@@ -133,6 +144,9 @@ Docker Compose
   sudo curl -L "${COMPOSE_URL}" -o /usr/local/bin/docker-compose
 
   sudo chmod +x /usr/local/bin/docker-compose
+
+Note: This option requires you to manage updates manually.
+It is recommended that you set up Docker's repository for easier maintenance.
 
 2. Verifying installation
 


### PR DESCRIPTION
This PR focuses on updating and formatting the contributors quick start guide.

As a new experimenting contributor, I had some troubles when I worked with the quick start guide, some commands that didn't work because of outdated packages, some instructions were unclear etc.

Addressing major changes I did:
1. Moving down the installation of the `docker compose plugin`: If we already have a section that is dedicated to the installation of docker compose, then commands that are relevant to its installation should be there, and not in a section that is dedicated to the installation of purely docker.
2. Sqlite -> sqlite3: according to the [Ubuntu package repository](https://packages.ubuntu.com/search?keywords=sqlite), the package `sqlite` is available only on `focal` and `jammy` Ubuntu distribution codenames. This means that the command `sudo apt install sqlite` will not work with any distributions beyond other than these two (like oracular, noble etc.). As I see it, these are the options:
a. Move to `sqlite3`. This would require performing tests, which I have - ran all the tests under the ./tests directory, which is probably not sufficient.
b. Add a note excluding distributions other than focal and jammy to use sqlite3 instead. This means developing on machines with distributions other than these may lead to inconsistencies as a result of breaking changes between the versions unless compatibility checks are done. 
This is very likely larger than my PR, and the best course of action for now is probably to delay this change until a decision is made, I made the changes only to raise awareness.
3. Removing section describing pre-commit with uv (lines 466-479): this content was just duplicated with the few lines below it. There are more examples of this behavior, but they are less aggressive so I decided to leave them be.

The other changes I made are mostly cosmetic.